### PR TITLE
Fix Vite bundling for React context

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,12 +17,8 @@ export default defineConfig(({ mode }) => ({
   build: {
     rollupOptions: {
       output: {
-        manualChunks(id) {
-          if (id.includes('node_modules')) {
-            if (id.includes('react')) return 'vendor-react';
-            if (id.includes('three')) return 'vendor-three';
-            return 'vendor';
-          }
+        manualChunks: {
+          'vendor-three': ['three', '@react-three/fiber', '@react-three/drei'],
         },
       },
     },


### PR DESCRIPTION
Simplify Vite bundling by removing manual chunking for React to resolve context loading errors on Vercel.